### PR TITLE
update: Remove "prepare" script in the package.json

### DIFF
--- a/ios/ExpoWidgets.podspec
+++ b/ios/ExpoWidgets.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platforms      = { :ios => "17.0" }
   s.swift_version  = '5.0'
   s.source         = { git: 'https://github.com/gitn00b1337/expo-widgets' }
   s.static_framework = true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
+    // "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "open:ios": "open -a \"Xcode\" example/ios",
     "open:android": "open -a \"Android Studio\" example/android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bittingz/expo-widgets",
-  "version": "2.9.0",
+  "version": "2.8.2",
   "description": "An expo module that allows you to make native widgets in iOS and android",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bittingz/expo-widgets",
-  "version": "2.8.2",
+  "version": "2.8.0",
   "description": "An expo module that allows you to make native widgets in iOS and android",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Try to fix the error when installing dependencies in eas building process:
`error https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "EEXIST: file already exists, mkdir '/Users/expo/Library/Caches/Yarn/v6/npm-argparse-1.0.10-bcd6791ea5ae09725e17e5ad988134cd40b3d911-integrity/node_modules/argparse/lib'"
`

Ref: https://expo.dev/accounts/hypebeast/projects/hype/builds/cdd2941c-d8ba-45e4-9a3a-5844432c16eb

Related solution: 
> I'm seeing the same issue with a project we have. However when I remove the deps that run a prepare script as part of the install (due to being git urls) then it works. These happen to be pointing git urls, but I think it's actually the prepare that seem to kick off more yarn install processes that seem to subvert the mutex flag for some reason. I wonder if that's because the other processes are kicked off by the root process rather than by different root processes. I don't know if this information helps or if its actually way off base. But I figured I would share what I've found regardless.

Ref: https://github.com/yarnpkg/yarn/issues/6312#issuecomment-422806004