### PR TITLE
update: Remove 'prepare' script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
+    // "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "open:ios": "open -a \"Xcode\" example/ios",
     "open:android": "open -a \"Android Studio\" example/android",


### PR DESCRIPTION
Try to fix the error when installing dependencies in eas building process:
`error https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "EEXIST: file already exists, mkdir '/Users/expo/Library/Caches/Yarn/v6/npm-argparse-1.0.10-bcd6791ea5ae09725e17e5ad988134cd40b3d911-integrity/node_modules/argparse/lib'" `

Ref: https://expo.dev/accounts/hypebeast/projects/hype/builds/cdd2941c-d8ba-45e4-9a3a-5844432c16eb

Related solution:

> I'm seeing the same issue with a project we have. However when I remove the deps that run a prepare script as part of the install (due to being git urls) then it works. These happen to be pointing git urls, but I think it's actually the prepare that seem to kick off more yarn install processes that seem to subvert the mutex flag for some reason. I wonder if that's because the other processes are kicked off by the root process rather than by different root processes. I don't know if this information helps or if its actually way off base. But I figured I would share what I've found regardless.

Ref: https://github.com/yarnpkg/yarn/issues/6312#issuecomment-422806004