### PR TITLE
fix: Fix auto generate app group id even with custom groupId issue

### DIFF
--- a/plugin/src/ios/withAppExtensions.ts
+++ b/plugin/src/ios/withAppExtensions.ts
@@ -8,7 +8,7 @@ import { getTargetName } from "./xcode/target"
 export const withAppExtensions: ConfigPlugin<WithExpoIOSWidgetsProps> = (config, options) => {
     const targetName = getTargetName(config, options)
     const bundleIdentifier = getBundleIdentifier(config, options)
-    const entitlement = getAppGroupEntitlement(config)
+    const entitlement = getAppGroupEntitlement(config, options)
     const appGroupEntitlements = (config.ios?.entitlements && config.ios.entitlements['com.apple.security.application-groups']) || []
   
     config.ios = {

--- a/plugin/src/ios/withAppGroupPermissions.ts
+++ b/plugin/src/ios/withAppGroupPermissions.ts
@@ -6,10 +6,14 @@ import { getPushNotificationsMode } from "./xcode/withEntitlements";
 
 const APP_GROUP_KEY = "com.apple.security.application-groups"
 
-export const getAppGroupEntitlement = (config: ExpoConfig) => {
-    return `group.${config?.ios?.bundleIdentifier || ""}.expowidgets`
-  }
-  
+export const getAppGroupEntitlement = (config: ExpoConfig, options: WithExpoIOSWidgetsProps) => {  
+  if (options.xcode?.appGroupId) {  
+      return options.xcode?.appGroupId  
+  }  
+    
+  return `group.${config?.ios?.bundleIdentifier || ""}.expowidgets`  
+}
+
 export const withAppGroupPermissions: ConfigPlugin<WithExpoIOSWidgetsProps> = (
     config,
     options
@@ -20,7 +24,7 @@ export const withAppGroupPermissions: ConfigPlugin<WithExpoIOSWidgetsProps> = (
       }
   
       const modResultsArray = (newConfig.modResults[APP_GROUP_KEY] as Array<any>);
-      const entitlement = getAppGroupEntitlement(config);
+      const entitlement = getAppGroupEntitlement(config, options);
   
       if (modResultsArray.indexOf(entitlement) !== -1) {
         Logging.logger.debug(`Adding entitlement ${entitlement} to config`)


### PR DESCRIPTION
- [fix: Fix auto generate app group id even with custom groupId issue](https://github.com/101medialab/expo-widgets/commit/831c64319526e4243455e8e314168ed36eb854ff)

Ref: https://expo.dev/accounts/hypebeast/projects/hype/builds/23a10f49-dfb0-4060-be51-c1c00af60312